### PR TITLE
dynamic join/leave buttons w/ state updates

### DIFF
--- a/src/app/events/page.js
+++ b/src/app/events/page.js
@@ -3,12 +3,14 @@
 import { useEffect, useState } from 'react';
 import { Button } from 'react-bootstrap';
 import { useRouter } from 'next/navigation';
+import { useAuth } from '@/utils/context/authContext';
 import { deleteEvent, getEvents } from '../../utils/sample-data/eventData';
 import EventCard from '../../components/event/EventCard';
 
 export default function EventsPage() {
   const [events, setEvents] = useState([]);
   const router = useRouter();
+  const { user } = useAuth();
 
   const deleteThisEvent = (id) => {
     deleteEvent(id).then(() => {
@@ -17,7 +19,10 @@ export default function EventsPage() {
   };
 
   useEffect(() => {
-    getEvents().then(setEvents);
+    getEvents(user.uid).then((data) => {
+      console.log('Fetched events:', data);
+      setEvents(data);
+    });
   }, []);
 
   return (
@@ -33,7 +38,7 @@ export default function EventsPage() {
       <article className="events">
         {events.map((event) => (
           <section key={`event--${event.id}`} className="event">
-            <EventCard id={event.id} game={event.game} description={event.description} date={event.date} time={event.time} organizer={event.organizer} deleteThisEvent={deleteThisEvent} />
+            <EventCard id={event.id} game={event.game} description={event.description} date={event.date} time={event.time} organizer={event.organizer} deleteThisEvent={deleteThisEvent} joined={event.joined} setEvents={setEvents} />
           </section>
         ))}
       </article>

--- a/src/components/event/EventCard.js
+++ b/src/components/event/EventCard.js
@@ -4,9 +4,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Card, Button } from 'react-bootstrap';
 import { useRouter } from 'next/navigation';
+import { useAuth } from '@/utils/context/authContext';
+import { joinEvent, leaveEvent } from '../../utils/sample-data/eventData';
 
-export default function EventCard({ id, game, description, date, time, organizer, deleteThisEvent }) {
+export default function EventCard({ id, game, description, date, time, organizer, deleteThisEvent, joined, setEvents }) {
   const router = useRouter();
+  const { user } = useAuth();
+  const handleJoin = () => joinEvent(id, user.uid, setEvents);
+  const handleLeave = () => leaveEvent(id, user.uid, setEvents);
 
   return (
     <div>
@@ -17,6 +22,8 @@ export default function EventCard({ id, game, description, date, time, organizer
         <Card.Body>
           <Card.Title>By: {organizer.uid}</Card.Title>
           <Card.Text>{game.title}</Card.Text>
+
+          {/* edit btn */}
           <Button
             onClick={() => {
               router.push(`/events/edit/${id}`);
@@ -25,9 +32,22 @@ export default function EventCard({ id, game, description, date, time, organizer
           >
             Edit
           </Button>
+
+          {/* delete btn */}
           <Button onClick={() => deleteThisEvent(id)} variant="danger">
             Delete
           </Button>
+
+          {/* join/leave btn */}
+          {joined ? (
+            <Button onClick={handleLeave} variant="warning">
+              Leave
+            </Button>
+          ) : (
+            <Button onClick={handleJoin} variant="success">
+              Join
+            </Button>
+          )}
         </Card.Body>
         <Card.Footer className="text-muted">{description}</Card.Footer>
       </Card>
@@ -43,4 +63,6 @@ EventCard.propTypes = {
   time: PropTypes.string.isRequired,
   organizer: PropTypes.string.isRequired,
   deleteThisEvent: PropTypes.func.isRequired,
+  joined: PropTypes.bool.isRequired,
+  setEvents: PropTypes.func.isRequired,
 };

--- a/src/utils/sample-data/eventData.js
+++ b/src/utils/sample-data/eventData.js
@@ -1,10 +1,14 @@
 /* eslint-disable consistent-return */
 import { clientCredentials } from '../client';
 
-const getEvents = () =>
+const getEvents = (uid) =>
   // eslint-disable-next-line no-new
   new Promise((resolve, reject) => {
-    fetch(`${clientCredentials.databaseURL}/events`)
+    fetch(`${clientCredentials.databaseURL}/events`, {
+      headers: {
+        Authorization: uid,
+      },
+    })
       .then((response) => response.json())
       .then(resolve)
       .catch(reject);
@@ -60,4 +64,32 @@ const deleteEvent = (id) =>
       .catch(reject);
   });
 
-export { getEvents, createEvent, updateEvent, getEventById, deleteEvent };
+const joinEvent = (eventId, uid, setEvents) => {
+  // TODO: Write the POST fetch request to join and event
+  fetch(`${clientCredentials.databaseURL}/events/${eventId}/signup`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: uid,
+    },
+    body: JSON.stringify({}),
+  })
+    .then(() => getEvents(uid))
+    .then(setEvents);
+};
+
+const leaveEvent = (eventId, uid, setEvents) => {
+  // TODO: Write the DELETE fetch request to leave an event
+  fetch(`${clientCredentials.databaseURL}/events/${eventId}/leave`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: uid,
+    },
+    body: JSON.stringify({}),
+  })
+    .then(() => getEvents(uid))
+    .then(setEvents);
+};
+
+export { getEvents, createEvent, updateEvent, getEventById, deleteEvent, joinEvent, leaveEvent };


### PR DESCRIPTION
This pull request introduces changes to enhance event functionality by adding user-specific event fetching and the ability to join or leave events. The updates include modifications to the `EventsPage` and `EventCard` components, as well as adjustments to the event data utility functions. 

### Event functionality enhancements:

* **User-specific event fetching:**
  - Updated `getEvents` in `src/utils/sample-data/eventData.js` to accept a `uid` parameter and include it in the `Authorization` header for fetching events specific to the logged-in user.
  - Modified `src/app/events/page.js` to pass the logged-in user's `uid` to `getEvents` and log the fetched events for debugging.

* **Join and leave event actions:**
  - Added `joinEvent` and `leaveEvent` functions in `src/utils/sample-data/eventData.js` to handle POST and DELETE requests for signing up or leaving events, respectively. These functions also refresh the event list after the action.
  - Updated `EventCard` in `src/components/event/EventCard.js` to include `joined` and `setEvents` props, and added buttons for joining or leaving events based on the user's participation status. [[1]](diffhunk://#diff-55d795f1109e355169942424d532dd48236d65592a974132a63cd74688909db4R35-R50) [[2]](diffhunk://#diff-55d795f1109e355169942424d532dd48236d65592a974132a63cd74688909db4R66-R67)

### Component updates:

* **EventsPage component:**
  - Integrated `useAuth` to access the logged-in user's information and pass `user.uid` to the event-fetching logic.
  - Updated `EventCard` usage to include the new `joined` and `setEvents` props.

* **EventCard component:**
  - Added `useAuth` for accessing user context and implemented `handleJoin` and `handleLeave` methods for event participation actions.
  - Extended `propTypes` to include `joined` and `setEvents` as required props.